### PR TITLE
Removed getRange method from diag collectors

### DIFF
--- a/jakarta-eclipse/src/org/jakarta/codeAction/CodeActionHandler.java
+++ b/jakarta-eclipse/src/org/jakarta/codeAction/CodeActionHandler.java
@@ -21,61 +21,68 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
-import org.jakarta.jdt.DiagnosticsCollector;
+import org.eclipse.lsp4j.Range;
+import org.jakarta.jdt.JDTUtils;
+import org.jakarta.jdt.JsonRpcHelpers;
+import org.jakarta.lsp4e.Activator;
 
 import io.microshed.jakartals.commons.JakartaJavaCodeActionParams;
 
-import org.jakarta.jdt.JDTUtils;
-
 /**
- * Code action handler.
- * Partially reused from https://github.com/eclipse/lsp4mp/blob/b88710cc54170844717f655b9bff8bb4c4649a8d/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/codeaction/CodeActionHandler.java
- * Modified to fit the purposes of the Jakarta Language Server with deletions of some unnecessary methods and modifications.
+ * Code action handler. Partially reused from
+ * https://github.com/eclipse/lsp4mp/blob/b88710cc54170844717f655b9bff8bb4c4649a8d/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/codeaction/CodeActionHandler.java
+ * Modified to fit the purposes of the Jakarta Language Server with deletions of
+ * some unnecessary methods and modifications.
+ *
  * @author credit to Angelo ZERR
  *
  */
-public class CodeActionHandler{
-	public List<CodeAction> codeAction(JakartaJavaCodeActionParams params, JDTUtils utils,
-			IProgressMonitor monitor, DiagnosticsCollector d){
+public class CodeActionHandler {
+
+	public List<CodeAction> codeAction(JakartaJavaCodeActionParams params, JDTUtils utils, IProgressMonitor monitor) {
 		String uri = params.getUri();
- 		ICompilationUnit unit = utils.resolveCompilationUnit(uri);
- 		if (unit == null) {
+		ICompilationUnit unit = utils.resolveCompilationUnit(uri);
+		if (unit == null) {
 			return Collections.emptyList();
 		}
- 		
- 		
-		ISourceRange nameRange = d.getRange();
-		if (nameRange == null) {
-			return Collections.emptyList();
-		}
-		int rangeLen = nameRange.getLength();
-		int rangeOffset = nameRange.getOffset();
-		
-		int start = rangeOffset;
-		int end = rangeOffset+ rangeLen;
-		JavaCodeActionContext context = new JavaCodeActionContext(unit, start, end - start, utils, params);
-		context.setASTRoot(getASTRoot(unit, monitor));
-		
-		List<CodeAction> codeActions = new ArrayList<>();
-		
-		HttpServletQuickFix HttpServletQuickFix = new HttpServletQuickFix();
-		for (Diagnostic diagnostic : params.getContext().getDiagnostics()) {
-			try {
-				codeActions.addAll(HttpServletQuickFix.getCodeActions(context, diagnostic, monitor));
-			} catch (CoreException e) {
-				e.printStackTrace();
+		try {
+			Range range = params.getRange();
+			int startOffset = toOffset(unit.getBuffer(), range.getStart().getLine(), range.getStart().getCharacter());
+			int endOffset = toOffset(unit.getBuffer(), range.getEnd().getLine(), range.getEnd().getCharacter());
+			JavaCodeActionContext context = new JavaCodeActionContext(unit, startOffset, endOffset - startOffset, utils,
+					params);
+			context.setASTRoot(getASTRoot(unit, monitor));
+
+			List<CodeAction> codeActions = new ArrayList<>();
+
+			HttpServletQuickFix HttpServletQuickFix = new HttpServletQuickFix();
+			for (Diagnostic diagnostic : params.getContext().getDiagnostics()) {
+				try {
+					codeActions.addAll(HttpServletQuickFix.getCodeActions(context, diagnostic, monitor));
+				} catch (CoreException e) {
+					e.printStackTrace();
+				}
 			}
+			return codeActions;
+
+		} catch (JavaModelException e) {
+			Activator.logException("Failed to retrieve Jakarta code action", e);
 		}
- 		return codeActions;
+		return null;
 	}
-	
+
 	private static CompilationUnit getASTRoot(ICompilationUnit unit, IProgressMonitor monitor) {
 		return CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, monitor);
+	}
+
+	public int toOffset(IBuffer buffer, int line, int column) {
+		return JsonRpcHelpers.toOffset(buffer, line, column);
 	}
 }

--- a/jakarta-eclipse/src/org/jakarta/jdt/DiagnosticsCollector.java
+++ b/jakarta-eclipse/src/org/jakarta/jdt/DiagnosticsCollector.java
@@ -9,5 +9,4 @@ import org.eclipse.jdt.core.ISourceRange;
 
 public interface DiagnosticsCollector {
 	public void collectDiagnostics(ICompilationUnit unit, List<Diagnostic> diagnostics);
-	public ISourceRange getRange();
 }

--- a/jakarta-eclipse/src/org/jakarta/jdt/FilterDiagnosticsCollector.java
+++ b/jakarta-eclipse/src/org/jakarta/jdt/FilterDiagnosticsCollector.java
@@ -63,9 +63,5 @@ public class FilterDiagnosticsCollector implements DiagnosticsCollector {
 			}
 		}
 	}
-	
-	public ISourceRange getRange() {
-		return null;
-	}
 
 }

--- a/jakarta-eclipse/src/org/jakarta/jdt/JDTServicesManager.java
+++ b/jakarta-eclipse/src/org/jakarta/jdt/JDTServicesManager.java
@@ -2,6 +2,7 @@ package org.jakarta.jdt;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -35,7 +36,7 @@ public class JDTServicesManager {
 		return INSTANCE;
 	}
 
-	public JDTServicesManager() {
+	private JDTServicesManager() {
 		diagnosticsCollectors.add(new ServletDiagnosticsCollector());
 		diagnosticsCollectors.add(new FilterDiagnosticsCollector());
 		diagnosticsCollectors.add(new ListenerDiagnosticsCollector());
@@ -49,19 +50,19 @@ public class JDTServicesManager {
 	 * @return diagnostics
 	 */
 	public List<PublishDiagnosticsParams> getJavaDiagnostics(JakartaDiagnosticsParams javaParams) {
-		List<PublishDiagnosticsParams> publishDiagnostics = new ArrayList<PublishDiagnosticsParams>();
-		List<Diagnostic> diagnostics = new ArrayList<>();
 		List<String> uris = javaParams.getUris();
+		if (uris == null) {
+			return Collections.emptyList();
+		}
 		
+		List<PublishDiagnosticsParams> publishDiagnostics = new ArrayList<PublishDiagnosticsParams>();
 		for (String uri : uris) {
-			
+			List<Diagnostic> diagnostics = new ArrayList<>();
 			URI u = JDTUtils.toURI(uri);
 			ICompilationUnit unit = JDTUtils.resolveCompilationUnit(u);
-//			System.out.println("--compiled unit: " + unit);
 			for (DiagnosticsCollector d : diagnosticsCollectors) {
 				d.collectDiagnostics(unit, diagnostics);
 			}
-			
 			PublishDiagnosticsParams publishDiagnostic = new PublishDiagnosticsParams(uri, diagnostics);
 			publishDiagnostics.add(publishDiagnostic);
 		}
@@ -108,6 +109,6 @@ public class JDTServicesManager {
  	
 	public List<CodeAction> getCodeAction(JakartaJavaCodeActionParams params,
 			JDTUtils utils, IProgressMonitor monitor) throws JavaModelException {
-		return codeActionHandler.codeAction(params, utils, monitor, diagnosticsCollectors.get(0));
+		return codeActionHandler.codeAction(params, utils, monitor);
  	}
 }

--- a/jakarta-eclipse/src/org/jakarta/jdt/ListenerDiagnosticsCollector.java
+++ b/jakarta-eclipse/src/org/jakarta/jdt/ListenerDiagnosticsCollector.java
@@ -70,8 +70,5 @@ public class ListenerDiagnosticsCollector implements DiagnosticsCollector {
 			}
 		}
 	}
-	
-	public ISourceRange getRange() {
-		return null;
-	}
+
 }

--- a/jakarta-eclipse/src/org/jakarta/jdt/ServletDiagnosticsCollector.java
+++ b/jakarta-eclipse/src/org/jakarta/jdt/ServletDiagnosticsCollector.java
@@ -56,8 +56,5 @@ public class ServletDiagnosticsCollector implements DiagnosticsCollector{
 			}
 		}
 	}
-	
-	public ISourceRange getRange() {
-		return this.nameRange;
-	}
+
 }

--- a/jakarta-eclipse/src/org/jakarta/lsp4e/JakartaLanguageClient.java
+++ b/jakarta-eclipse/src/org/jakarta/lsp4e/JakartaLanguageClient.java
@@ -56,9 +56,6 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
 
 	@Override
 	public CompletableFuture<List<PublishDiagnosticsParams>> getJavaDiagnostics(JakartaDiagnosticsParams javaParams) {
-		Activator.log(new Status(IStatus.INFO, "diagnostic request received", "diagnostic request receieved"));
-		// creating a test diagnostic
-		// problem! the Async leads to diagnostic msg not sync with the changes on the client side
 		return CompletableFutures.computeAsync((cancelChecker) -> {
 			IProgressMonitor monitor = getProgressMonitor(cancelChecker);
 
@@ -84,11 +81,12 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
 
 	public CompletableFuture<List<CodeAction>> getCodeAction(CodeActionParams params){
 		JDTUtils utils = new JDTUtils();
-		JakartaJavaCodeActionParams JakartaParams = new JakartaJavaCodeActionParams(params.getTextDocument(), params.getRange(), params.getContext());
+
 		return CompletableFutures.computeAsync((cancelChecker) -> {
 			IProgressMonitor monitor = getProgressMonitor(cancelChecker);
 			try {
-				return JDTServicesManager.getInstance().getCodeAction(JakartaParams, utils, monitor);
+				JakartaJavaCodeActionParams JakartaParams = new JakartaJavaCodeActionParams(params.getTextDocument(), params.getRange(), params.getContext());
+				return (List<CodeAction>) JDTServicesManager.getInstance().getCodeAction(JakartaParams, utils, monitor);
 			} catch (JavaModelException e) {
 				return null;
 			}

--- a/jakarta.ls/pom.xml
+++ b/jakarta.ls/pom.xml
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <lsp4j.version>0.9.0</lsp4j.version>
+    <lsp4j.version>0.10.0</lsp4j.version>
   </properties>
 
   <dependencies>

--- a/jakarta.ls/src/main/java/io/microshed/jakartals/JakartaLanguageServer.java
+++ b/jakarta.ls/src/main/java/io/microshed/jakartals/JakartaLanguageServer.java
@@ -7,6 +7,7 @@ import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
@@ -39,6 +40,8 @@ public class JakartaLanguageServer implements LanguageServer, ProcessLanguageSer
     LOGGER.info("Initializing Jakarta EE server");
     this.parentProcessId = params.getProcessId();
     ServerCapabilities serverCapabilities = new ServerCapabilities();
+    serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);
+
     InitializeResult initializeResult = new InitializeResult(serverCapabilities);
     // Provide Completion Capability to the LS
     initializeResult.getCapabilities().setCompletionProvider(new CompletionOptions());


### PR DESCRIPTION
- Minor formatting changes
- bumped version of lsp4j to `0.10.0`
- added `serverCapabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);` to language server in order to trigger diagnostics on save
- removed the use of the `getRange()` method from the diagnostic collectors, as the range for code actions can be calculated from the code action params

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>